### PR TITLE
fix: refresh handling | style: points display

### DIFF
--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -11,6 +11,7 @@ const Admin = () => {
   const { user } = useContext(SessionUserContext);
   const navigate = useNavigate();
 
+  const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("term");
 
   const handleSelectTab = (selectedTab) => {
@@ -28,10 +29,14 @@ const Admin = () => {
   };
 
   useEffect(() => {
-    if (!user?.is_admin && !user?.is_superuser) {
-      navigate("/swtd");
+    if (!user) setLoading(true);
+    else {
+      setLoading(false);
+      if (!user?.is_admin && !user?.is_superuser) navigate("/swtd");
     }
-  });
+  }, [user, navigate]);
+
+  if (loading) return null;
 
   return (
     <Container className="d-flex flex-column justify-content-start align-items-start">

--- a/src/pages/dashboard/EmployeeSWTD.js
+++ b/src/pages/dashboard/EmployeeSWTD.js
@@ -21,6 +21,7 @@ const EmployeeSWTD = () => {
   const token = Cookies.get("userToken");
   const navigate = useNavigate();
 
+  const [loading, setLoading] = useState(false);
   const [userSWTDs, setUserSWTDs] = useState([]);
   const [employee, setEmployee] = useState(null);
   const [termStatus, setTermStatus] = useState(null);
@@ -142,14 +143,20 @@ const EmployeeSWTD = () => {
   );
 
   useEffect(() => {
-    if (!user?.is_admin && !user?.is_staff && !user?.is_superuser) {
-      navigate("/swtd");
+    if (!user) setLoading(true);
+    else {
+      setLoading(false);
+      if (!user?.is_admin && !user?.is_staff && !user?.is_superuser)
+        navigate("/swtd");
+      else {
+        fetchUser();
+        fetchTerms();
+        fetchAllSWTDs();
+      }
     }
+  }, [user, navigate]);
 
-    fetchUser();
-    fetchTerms();
-    fetchAllSWTDs();
-  }, []);
+  if (loading) return null;
 
   return (
     <Container className="d-flex flex-column justify-content-start align-items-start">
@@ -180,72 +187,96 @@ const EmployeeSWTD = () => {
       </Row>
 
       <Row className={`${styles.employeeDetails} w-100 mb-3`}>
-        <Col className="d-flex align-items-center" xs="auto">
-          <i className="fa-regular fa-calendar me-2"></i> Term:{" "}
-          {terms.length === 0 ? (
-            <>No terms were added yet.</>
-          ) : (
-            <DropdownButton
-              className={`ms-2`}
-              variant={
-                selectedTerm?.is_ongoing === true ? "success" : "secondary"
-              }
-              size="sm"
-              title={selectedTerm ? selectedTerm.name : "All terms"}>
-              <Dropdown.Item onClick={() => setSelectedTerm(null)}>
-                All terms
-              </Dropdown.Item>
-              {terms &&
-                terms.map((term) => (
-                  <Dropdown.Item
-                    key={term.id}
-                    onClick={() => {
-                      fetchClearanceStatus(term);
-                      setSelectedTerm(term);
-                    }}>
-                    {term.name}
+        <Col className="d-flex align-items-center">
+          <Row>
+            <Col className="d-flex align-items-center" xs="auto">
+              <i className="fa-regular fa-calendar me-2"></i> Term:{" "}
+              {terms.length === 0 ? (
+                <>No terms were added yet.</>
+              ) : (
+                <DropdownButton
+                  className={`ms-2`}
+                  variant={
+                    selectedTerm?.is_ongoing === true ? "success" : "secondary"
+                  }
+                  size="sm"
+                  title={selectedTerm ? selectedTerm.name : "All terms"}>
+                  <Dropdown.Item onClick={() => setSelectedTerm(null)}>
+                    All terms
                   </Dropdown.Item>
-                ))}
-            </DropdownButton>
-          )}
+                  {terms &&
+                    terms.map((term) => (
+                      <Dropdown.Item
+                        key={term.id}
+                        onClick={() => {
+                          fetchClearanceStatus(term);
+                          setSelectedTerm(term);
+                        }}>
+                        {term.name}
+                      </Dropdown.Item>
+                    ))}
+                </DropdownButton>
+              )}
+            </Col>
+            <Col className="d-flex align-items-center" xs="auto">
+              <i className="fa-solid fa-building me-2"></i>Department:{" "}
+              {employee?.department}
+            </Col>
+            {selectedTerm === null && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-circle-plus me-2"></i>Point Balance:{" "}
+                {employee?.point_balance}
+              </Col>
+            )}
+
+            {/* {selectedTerm && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-circle-plus me-2"></i>Term Points:{" "}
+                <span
+                  className={`ms-1 ${
+                    termStatus?.points?.valid_points <
+                    termStatus?.points?.required_points
+                      ? "text-danger"
+                      : "text-success"
+                  }`}>
+                  {termStatus?.points?.valid_points} /{" "}
+                  {termStatus?.points?.required_points}
+                </span>
+              </Col>
+            )} */}
+
+            {selectedTerm !== null && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-user-check me-2"></i>Status:{" "}
+                <span
+                  className={`ms-2 text-${
+                    termStatus?.is_cleared ? "success" : "danger"
+                  }`}>
+                  {termStatus?.is_cleared ? "CLEARED" : "PENDING CLEARANCE"}
+                </span>
+              </Col>
+            )}
+          </Row>
         </Col>
-
-        <Col className="d-flex align-items-center" xs="auto">
-          <i className="fa-solid fa-building me-2"></i>Department:{" "}
-          {employee?.department}
-        </Col>
-
-        {selectedTerm === null && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-circle-plus me-2"></i>Point Balance:{" "}
-            {employee?.point_balance}
-          </Col>
-        )}
-
-        {selectedTerm && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-circle-plus me-2"></i>Term Points:{" "}
-            <span
-              className={`ms-1 ${
-                termStatus?.points?.valid_points <
-                termStatus?.points?.required_points
-                  ? "text-danger"
-                  : "text-success"
-              }`}>
-              {termStatus?.points?.valid_points}
-            </span>
-          </Col>
-        )}
 
         {selectedTerm !== null && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-user-check me-2"></i>Status:{" "}
-            <span
-              className={`ms-2 text-${
-                termStatus?.is_cleared ? "success" : "danger"
-              }`}>
-              {termStatus?.is_cleared ? "CLEARED" : "PENDING CLEARANCE"}
-            </span>
+          <Col className={`${styles.termPoints} text-end`} md={2}>
+            <div>
+              <span
+                className={`${styles.validPoints} ${
+                  termStatus?.points?.valid_points <
+                  termStatus?.points?.required_points
+                    ? "text-danger"
+                    : "text-success"
+                }`}>
+                {termStatus?.points?.valid_points}
+              </span>
+              <span className={styles.requiredPoints}>
+                {" "}
+                / {termStatus?.points?.required_points}
+              </span>
+            </div>
+            <span className={styles.pointsLabel}>points</span>
           </Col>
         )}
       </Row>

--- a/src/pages/dashboard/ViewSWTD.js
+++ b/src/pages/dashboard/ViewSWTD.js
@@ -23,6 +23,7 @@ const ViewSWTD = () => {
   const token = Cookies.get("userToken");
   const userID = parseInt(Cookies.get("userID"), 10);
 
+  const [loading, setLoading] = useState(false);
   const [swtd, setSWTD] = useState(null);
   const [swtdProof, setSWTDProof] = useState(null);
 
@@ -192,14 +193,20 @@ const ViewSWTD = () => {
   };
 
   useEffect(() => {
-    if (!user?.is_admin && !user?.is_staff && !user?.is_superuser) {
-      navigate("/swtd");
+    if (!user) setLoading(true);
+    else {
+      setLoading(false);
+      if (!user?.is_admin && !user?.is_staff && !user?.is_superuser)
+        navigate("/swtd");
+      else {
+        fetchSWTD();
+        fetchSWTDValidation();
+        fetchComments();
+      }
     }
+  }, [user, navigate]);
 
-    fetchSWTD();
-    fetchSWTDValidation();
-    fetchComments();
-  }, []);
+  if (loading) return null;
 
   return (
     <Container className="d-flex flex-column justify-content-start align-items-start">

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -17,6 +17,7 @@ const Dashboard = () => {
   const token = Cookies.get("userToken");
   const userID = Cookies.get("userID");
 
+  const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedDepartment, setSelectedDepartment] = useState(null);
 
@@ -34,14 +35,6 @@ const Dashboard = () => {
     );
   };
 
-  useEffect(() => {
-    if (!user?.is_admin && !user?.is_staff && !user?.is_superuser) {
-      navigate("/swtd");
-    }
-
-    fetchAllUsers();
-  }, []);
-
   const handleEmployeeSWTDClick = (id) => {
     navigate(`/dashboard/${id}`);
   };
@@ -54,6 +47,18 @@ const Dashboard = () => {
         user.lastname.toLowerCase().includes(searchQuery.toLowerCase()) ||
         user.employee_id.includes(searchQuery))
   );
+
+  useEffect(() => {
+    if (!user) setLoading(true);
+    else {
+      setLoading(false);
+      if (!user?.is_admin && !user?.is_staff && !user?.is_superuser)
+        navigate("/swtd");
+      else fetchAllUsers();
+    }
+  }, [user, navigate]);
+
+  if (loading) return null;
 
   return (
     <Container className="d-flex flex-column justify-content-start align-items-start">

--- a/src/pages/dashboard/style.module.css
+++ b/src/pages/dashboard/style.module.css
@@ -87,3 +87,16 @@
   font-family: "Poppins-SemiBold";
   color: #d80085;
 }
+
+.termPoints {
+  font-family: "Degradasi";
+  line-height: 1.3em;
+}
+
+.validPoints {
+  font-size: 2.3em;
+}
+
+.requiredPoints {
+  font-size: 1.3em;
+}

--- a/src/pages/employee dashboard/AddSWTD.js
+++ b/src/pages/employee dashboard/AddSWTD.js
@@ -25,6 +25,7 @@ const AddSWTD = () => {
   const navigate = useNavigate();
   const inputFile = useRef(null);
 
+  const [loading, setLoading] = useState(false);
   const [showSuccess, triggerShowSuccess] = useTrigger(false);
   const [showError, triggerShowError] = useTrigger(false);
   const [errorMessage, setErrorMessage] = useState(null);

--- a/src/pages/employee dashboard/EditSWTD.js
+++ b/src/pages/employee dashboard/EditSWTD.js
@@ -28,6 +28,7 @@ const EditSWTD = () => {
   const token = Cookies.get("userToken");
   const id = parseInt(Cookies.get("userID"), 10);
 
+  const [loading, setLoading] = useState(true);
   const [swtd, setSWTD] = useState(null);
   const [swtdProof, setSWTDProof] = useState(null);
 
@@ -107,9 +108,11 @@ const EditSWTD = () => {
         });
         setTerm(data.term.id);
         fetchClearance(data.term.id);
+        setLoading(false);
       },
       (error) => {
         console.log("Error fetching SWTD data: ", error);
+        setLoading(false);
       }
     );
   };
@@ -310,7 +313,10 @@ const EditSWTD = () => {
     fetchSWTD();
     fetchTerms();
     fetchSWTDValidation();
+    if (swtd) setLoading(false);
   }, []);
+
+  if (loading) return null;
 
   return (
     <div className={styles.background}>

--- a/src/pages/employee dashboard/index.js
+++ b/src/pages/employee dashboard/index.js
@@ -102,98 +102,118 @@ const SWTDDashboard = () => {
 
   return (
     <Container className="d-flex flex-column justify-content-start align-items-start">
-      <Row className="w-100 mb-2">
-        <Col>
-          <h3 className={`${styles.label} d-flex align-items-center`}>
-            SWTD Points Overview
-            <i
-              className={`${styles.commentEdit} fa-solid fa-circle-info fa-xs ms-2`}
-              onClick={openPointsModal}></i>
-          </h3>
-          <Modal
-            show={showPointsModal}
-            onHide={closePointsModal}
-            size="lg"
-            centered>
-            <Modal.Header closeButton>
-              <Modal.Title className={styles.formLabel}>
-                Required Points & Compliance Schedule
-              </Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-              <SWTDInfo />
-            </Modal.Body>
-          </Modal>
-        </Col>
+      <Row className="w-100">
+        <h3 className={`${styles.label} d-flex align-items-center`}>
+          SWTD Points Overview
+          <i
+            className={`${styles.commentEdit} fa-solid fa-circle-info fa-xs ms-2`}
+            onClick={openPointsModal}></i>
+        </h3>
+        <Modal
+          show={showPointsModal}
+          onHide={closePointsModal}
+          size="lg"
+          centered>
+          <Modal.Header closeButton>
+            <Modal.Title className={styles.formLabel}>
+              Required Points & Compliance Schedule
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <SWTDInfo />
+          </Modal.Body>
+        </Modal>
       </Row>
 
       <Row className={`${styles.employeeDetails} w-100 mb-3`}>
-        <Col className="d-flex align-items-center" xs="auto">
-          <i className="fa-regular fa-calendar me-2"></i> Term:{" "}
-          {terms.length === 0 ? (
-            <>No terms were added yet.</>
-          ) : (
-            <DropdownButton
-              className={`ms-2`}
-              variant={
-                selectedTerm?.is_ongoing === true ? "success" : "secondary"
-              }
-              size="sm"
-              title={selectedTerm ? selectedTerm.name : "All terms"}>
-              <Dropdown.Item onClick={() => setSelectedTerm(null)}>
-                All terms
-              </Dropdown.Item>
-              {terms &&
-                terms.map((term) => (
-                  <Dropdown.Item
-                    key={term.id}
-                    onClick={() => {
-                      fetchClearanceStatus(term);
-                      setSelectedTerm(term);
-                    }}>
-                    {term.name}
+        <Col className="d-flex align-items-center">
+          <Row>
+            <Col className="d-flex align-items-center" xs="auto">
+              <i className="fa-regular fa-calendar me-2"></i> Term:{" "}
+              {terms.length === 0 ? (
+                <>No terms were added yet.</>
+              ) : (
+                <DropdownButton
+                  className={`ms-2`}
+                  variant={
+                    selectedTerm?.is_ongoing === true ? "success" : "secondary"
+                  }
+                  size="sm"
+                  title={selectedTerm ? selectedTerm.name : "All terms"}>
+                  <Dropdown.Item onClick={() => setSelectedTerm(null)}>
+                    All terms
                   </Dropdown.Item>
-                ))}
-            </DropdownButton>
-          )}
+                  {terms &&
+                    terms.map((term) => (
+                      <Dropdown.Item
+                        key={term.id}
+                        onClick={() => {
+                          fetchClearanceStatus(term);
+                          setSelectedTerm(term);
+                        }}>
+                        {term.name}
+                      </Dropdown.Item>
+                    ))}
+                </DropdownButton>
+              )}
+            </Col>
+            <Col className="d-flex align-items-center" xs="auto">
+              <i className="fa-solid fa-building me-2"></i>Department:{" "}
+              {user?.department}
+            </Col>
+            {selectedTerm === null && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-circle-plus me-2"></i>Point Balance:{" "}
+                {user?.point_balance}
+              </Col>
+            )}
+            {/* {selectedTerm && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-circle-plus me-2"></i>Term Points:{" "}
+                <span
+                  className={`ms-1 ${
+                    termStatus?.points?.valid_points <
+                    termStatus?.points?.required_points
+                      ? "text-danger"
+                      : "text-success"
+                  }`}>
+                  {termStatus?.points?.valid_points} /{" "}
+                  {termStatus?.points?.required_points}
+                </span>
+              </Col>
+            )} */}
+            {selectedTerm !== null && (
+              <Col className="d-flex align-items-center" xs="auto">
+                <i className="fa-solid fa-user-check me-2"></i>Status:{" "}
+                <span
+                  className={`ms-2 text-${
+                    termStatus?.is_cleared ? "success" : "danger"
+                  }`}>
+                  {termStatus?.is_cleared ? "CLEARED" : "PENDING CLEARANCE"}
+                </span>
+              </Col>
+            )}
+          </Row>
         </Col>
-
-        <Col className="d-flex align-items-center" xs="auto">
-          <i className="fa-solid fa-building me-2"></i>Department:{" "}
-          {user?.department}
-        </Col>
-
-        {selectedTerm === null && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-circle-plus me-2"></i>Point Balance:{" "}
-            {user?.point_balance}
-          </Col>
-        )}
-
-        {selectedTerm && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-circle-plus me-2"></i>Term Points:{" "}
-            <span
-              className={`ms-1 ${
-                termStatus?.points?.valid_points <
-                termStatus?.points?.required_points
-                  ? "text-danger"
-                  : "text-success"
-              }`}>
-              {termStatus?.points?.valid_points}
-            </span>
-          </Col>
-        )}
 
         {selectedTerm !== null && (
-          <Col className="d-flex align-items-center" xs="auto">
-            <i className="fa-solid fa-user-check me-2"></i>Status:{" "}
-            <span
-              className={`ms-2 text-${
-                termStatus?.is_cleared ? "success" : "danger"
-              }`}>
-              {termStatus?.is_cleared ? "CLEARED" : "PENDING CLEARANCE"}
-            </span>
+          <Col className={`${styles.termPoints} text-end`} md={2}>
+            <div>
+              <span
+                className={`${styles.validPoints} ${
+                  termStatus?.points?.valid_points <
+                  termStatus?.points?.required_points
+                    ? "text-danger"
+                    : "text-success"
+                }`}>
+                {termStatus?.points?.valid_points}
+              </span>
+              <span className={styles.requiredPoints}>
+                {" "}
+                / {termStatus?.points?.required_points}
+              </span>
+            </div>
+            <span className={styles.pointsLabel}>points</span>
           </Col>
         )}
       </Row>

--- a/src/pages/employee dashboard/style.module.css
+++ b/src/pages/employee dashboard/style.module.css
@@ -99,3 +99,16 @@
   font-family: "Poppins-SemiBold";
   color: #d80085;
 }
+
+.termPoints {
+  font-family: "Degradasi";
+  line-height: 1.3em;
+}
+
+.validPoints {
+  font-size: 2.3em;
+}
+
+.requiredPoints {
+  font-size: 1.3em;
+}


### PR DESCRIPTION
## Fixes
- Changed refresh handling for the Dashboard and Admin pages
- Page rendering for URLs a user is not supposed to access. The following cases being handled:
  - User entering the URL for Dashboard (Admin/Staff) and Admin pages
  - User entering the URL for SWTDs that are not theirs 

## Changes
- When selecting a term, the points display is now more obvious. The display shows the valid points the user has over the required points. In this image, the current user has zero (0) points and the required points is ten (10).
![image](https://github.com/ArchonsDev/react-pointwatch-web/assets/62651994/186ddd69-6348-4e33-a426-0599be5a5b90)

- This change also applies to Dashboard > Employee display
![image](https://github.com/ArchonsDev/react-pointwatch-web/assets/62651994/90297020-fcf9-4345-aa54-a6c06888e67a)
![image](https://github.com/ArchonsDev/react-pointwatch-web/assets/62651994/3236fbea-e477-4023-a5ec-b9bb2807c934)